### PR TITLE
Add rudimentary language filters

### DIFF
--- a/site.css
+++ b/site.css
@@ -119,3 +119,7 @@ h2 {
 #footer {
   display: none;
 }
+
+.language-picker {
+  text-align: center;
+}


### PR DESCRIPTION
refs: https://github.com/servo/servo-starters/issues/8
- Assumes all repos implicitly have a rust tag (this is wrong for highfive and possibly other projects) 
- Defaults to having all languages selected
- Clicking a language tag includes or excludes issues with that tag 

Code might need some cleanup (normalized indentation, merge labels and filter labels, maybe get rid of some for loops).

<img width="650" alt="screen shot 2015-12-01 at 1 16 00 am" src="https://cloud.githubusercontent.com/assets/226605/11493671/1da10ec2-97c9-11e5-9f90-82cecbddd590.png">
