### PR TITLE
Don't display issues that are assigned but haven't been updated in a …

### DIFF
--- a/site.js
+++ b/site.js
@@ -81,6 +81,9 @@ var extractFunction = function (callback) {
 
     all.sort(timeSort);
     all.map(addDefaultLanguageLabel);
+    all.filter(function(issue) {
+      return issue.labels.indexOf("C-has open PR") === -1;
+    });
     callback(all);
   };
 };


### PR DESCRIPTION
…while if they are associated with an open PR.
