### PR TITLE
Adding a link to the tag names of GitHub

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,12 +42,16 @@
             <em>Servo Starters</em> is a list of easy tasks that are good for
             beginners to rust or servo.
             </p>
+            
+            <p>
+            To help find issues that follow your interests, make sure to look over our list of <a href="https://github.com/servo/servo/wiki/Tag-label-names-and-definitions">tags</a>
+            </p>
 
             <p>
             If you want to work on an issue, make sure to claim it by commenting on it before working on it!
             Check out our <a href="https://github.com/servo/servo/blob/master/CONTRIBUTING.md">CONTRIBUTING.md</a> for more helpful tips on how to contribute to Servo.
             </p>
-
+            
             <div id="app"></div>
         </div>
         <div id="footer">


### PR DESCRIPTION
This is a proposal I have to work towards implementing @jdm's issue #37
