### PR TITLE
Issues pulled from Anidata, removed default language labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,8 +1,8 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
     <head>
         <meta charset="utf-8">
-        <title>Servo Starters - Whet your appetite with these easy servo tasks</title>
+        <title>Anidata.Github.io Starters</title>
 
         <link href="normalize.css" rel="stylesheet">
         <link href="site.css" rel="stylesheet">
@@ -26,36 +26,25 @@
     </head>
 
     <body>
-        <a href="https://github.com/servo/servo-starters">
-            <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/652c5b9acfaddf3a9c326fa6bde407b87f7be0f4/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6f72616e67655f6666373630302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png">
-        </a>
         <div id="content">
             <h1>
-            Servo Starters
+              Anidata.github.io Starters
             </h1>
 
             <p>
-            Contributing to Mozilla <a href="https://github.com/servo/servo">Servo</a> is fun!
+              Contributing to <a href="https://github.com/anidata/anidata.github.io">Anidata</a> is fun!
             </p>
 
             <p>
             Sometimes it's hard to know where to get started, though.
-            <em>Servo Starters</em> is a list of easy tasks that are good for
-            beginners to rust or servo.
-            </p>
-            <p>Issue tags are explained <a href="https://github.com/servo/servo/wiki/Tag-label-names-and-definitions">here</a>.
-            If you can't find an issue that meets your needs, comment <a href="https://github.com/servo/servo/issues/15162">here</a>!
-            </p>
-            
-            <p>
-            To help find issues that follow your interests, make sure to look over our list of <a href="https://github.com/servo/servo/wiki/Tag-label-names-and-definitions">tags</a>
+            <em>Anidata Starters</em> is a list of easy tasks that are good for
+            beginners.
             </p>
 
             <p>
-            If you want to work on an issue, make sure to claim it by commenting on it before working on it!
-            Check out our <a href="https://github.com/servo/servo/blob/master/CONTRIBUTING.md">CONTRIBUTING.md</a> for more helpful tips on how to contribute to Servo.
+            To help find issues that follow your interests, make sure to look over our list of <a href="https://github.com/anidata/anidata.github.io/labels">tags</a>
             </p>
-            
+
             <div id="app"></div>
         </div>
         <script src="site.js"></script>

--- a/site.js
+++ b/site.js
@@ -6,6 +6,20 @@ var timeSort = function (l, r) {
     return r.created_at.localeCompare(l.created_at);
 };
 
+var langLabels = [{
+    name: 'lang-python',
+    color: 'bfd4f2',
+    url: 'https://api.github.com/servo/servo/labels/L-python',
+    selected: true
+  },
+  {
+    name: 'lang-javascript',
+    color: 'bfd4f2',
+    url: 'https://api.github.com/servo/servo/labels/L-python',
+    selected: true
+  },
+]
+
 var getIssueLanguageLabel = function (issue) {
     for (var i = 0; i < issue.labels.length; i++) {
         var label = issue.labels[i];
@@ -39,7 +53,7 @@ var getOpenIssues = function (callback) {
     })
 
     var dataExtractor = extractFunction(callback);
-    $.when(all).done(dataExtractor);
+    $.when(issues).done(dataExtractor);
 };
 
 var makeLabelFriendly = function (label) {


### PR DESCRIPTION
I've got the starters page to pull issues from Anidata instead of Servo now, and changed the text of the page to suit Anidata instead of Mozilla. The language filters at the top of the page don't currently work, but that's a trivial fix that I should be able to take care of shortly. 