### PR TITLE
Add HTML lang attribute and remove obsolete `script` charset attribute

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en-US">
     <head>
         <meta charset="utf-8">
         <title>Servo Starters - Whet your appetite with these easy Servo tasks</title>
@@ -13,16 +13,13 @@
 
         <script src="https://cdnjs.cloudflare.com/ajax/libs/react/0.14.7/react.min.js"
                 integrity="sha512-MkL0QRXlxubtyaWFJh8yWiRhaQrc+SeFfdvjwFwnUjvB/ZgCaMYlYxJ+JdzfiCYYV+cQ3MMwv+lV685SXxK0/Q=="
-                crossorigin="anonymous"
-                charset="utf-8"></script>
+                crossorigin="anonymous"></script>
         <script src="https://code.jquery.com/jquery-2.2.1.min.js"
                 integrity="sha512-chZc2Mx8B1GzGSNMfJRH63jW7uYZXzX0a/UlWRrTvl4kxxYqUHNMtyTTA5IDQ7gTl4ATLoXlZthsialW3muS0A=="
-                crossorigin="anonymous"
-                charset="utf-8"></script>
+                crossorigin="anonymous"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.12.0/moment.min.js"
                 integrity="sha512-vjqLmddiMORo2KKnzvlZ0fMnp7Z8+U+PIzG8h/TLVhZyXpbvdfiaPiZCVtzMIC91TeM5mNKIbTIMMlPAH70uoA=="
-                crossorigin="anonymous"
-                charset="utf-8"></script>
+                crossorigin="anonymous"></script>
     </head>
 
     <body>


### PR DESCRIPTION
* Add `lang="en-US"` to the `html` tag
* Remove obsolete `charset` attribute from `script` tag

---

From Nu HTML Validator: https://validator.w3.org/nu/?doc=https%3A%2F%2Fstarters.servo.org%2F

![image](https://user-images.githubusercontent.com/37223377/89721539-8c91b280-d993-11ea-8ef0-98cbd8e8755e.png)

Cc servo/servo.org#108